### PR TITLE
Do not use a file with a predictable name in /tmp

### DIFF
--- a/YubiKey_NEO.rst
+++ b/YubiKey_NEO.rst
@@ -95,11 +95,11 @@ If running gnome, this problem may be solved by running the following to disable
 Next, place the following in ``~/.bashrc`` to ensure gpg-agent starts with ``--enable-ssh-support``
 ::
 
-    if [ ! -f /tmp/gpg-agent.env ]; then
+    if [ ! -f /run/user/($id -u)/gpg-agent.env ]; then
         killall gpg-agent;
-        eval $(gpg-agent --daemon --enable-ssh-support > /tmp/gpg-agent.env);
+        eval $(gpg-agent --daemon --enable-ssh-support > /run/user/($id -u)/gpg-agent.env);
     fi
-    . /tmp/gpg-agent.env
+    . /run/user/($id -u)/gpg-agent.env
 
 Now go to next step (Reload GNOME-Shell) :)
 


### PR DESCRIPTION
Using a file with a predicatable name in /tmp is likely a source of trouble on a shared system, since /tmp/ may be shared among all users. /run/user/ is made for that, cleaned on reboot, and properly protected from interference from others. It requires systemd and a newer system.
