### PR TITLE
Make instructions accurate for recent Fedora

### DIFF
--- a/Gemalto_USB_Shell_Token.rst
+++ b/Gemalto_USB_Shell_Token.rst
@@ -20,10 +20,6 @@ Certain software must be installed, including ``gnupg2`` (which is probably alre
 Configure GNOME-Shell to use gpg-agent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Turn off ssh-agent inside gnome-keyring-daemon::
-
-  $ gconftool-2 --type bool --set /apps/gnome-keyring/daemon-components/ssh false
-
 Configure gpg to use agent (only for smartcard)::
 
   $ gpg --list-keys | head -n 1

--- a/YubiKey_NEO.rst
+++ b/YubiKey_NEO.rst
@@ -49,8 +49,6 @@ Allow admin actions on your YubiKey (if your gnupg version is < 2.0.11)::
 
   $ echo "allow-admin" >>  ~/.gnupg/scdaemon.conf
 
-Then, comment out the ``use-ssh-agent`` line in ``/etc/X11/XSession.options`` file.
-
 
 Intercept gnome-keyring-daemon and put gpg-agent in place for ssh authentication (Ubuntu)
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -71,6 +69,8 @@ Add the following lines to the post-stop script section::
 
   initctl unset-env --global SSH_AUTH_SOCK
   initctl unset-env --global SSH_AGENT_PID
+
+Comment out the ``use-ssh-agent`` line in ``/etc/X11/XSession.options`` file.
 
 Disable the other system gpg-agent::
 

--- a/YubiKey_NEO.rst
+++ b/YubiKey_NEO.rst
@@ -37,12 +37,6 @@ If you have a dev key, Reboot your yubikey (remove and reinsert) so that ykneomg
 Configure GNOME-Shell to use gpg-agent and disable ssh-agent
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Turn off ssh-agent inside gnome-keyring-daemon::
-
-  if [[ $(gconftool-2 --get /apps/gnome-keyring/daemon-components/ssh) != "false" ]]; then
-    gconftool-2 --type bool --set /apps/gnome-keyring/daemon-components/ssh false
-  fi
-
 Configure GPG to use its agent (only for smartcard)::
 
   $ echo "use-agent" >> ~/.gnupg/gpg.conf
@@ -86,11 +80,15 @@ Note: We could have used the Xsession gpg-agent and trashed the upstart one, but
 
 Intercept gnome-keyring-daemon and put gpg-agent in place for ssh authentication (Fedora)
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-If running gnome, this problem may be solved by running the following to disable gnome-keyring from autostarting its broken gpg-agent and ssh-agent implementation::
+If running gnome, you have to prevent gnome-keyring from autostarting its ssh-agent implementation, because we will use GPG's instead:
 
-  mv /etc/xdg/autostart/gnome-keyring-gpg.desktop /etc/xdg/autostart/gnome-keyring-gpg.desktop.inactive
-    
-  mv /etc/xdg/autostart/gnome-keyring-ssh.desktop /etc/xdg/autostart/gnome-keyring-ssh.desktop.inactive
+  sed -e '$aX-GNOME-Autostart-enabled=false' -e '$aHidden=true' \
+      /etc/xdg/autostart/gnome-keyring-ssh.desktop > $HOME/.config/autostart/gnome-keyring-ssh.desktop
+
+On GNOME 3.16 or earlier, do the same for the broken gpg-agent implementation, which does not support smartcards:
+
+  sed -e '$aX-GNOME-Autostart-enabled=false' -e '$aHidden=true' \
+      /etc/xdg/autostart/gnome-keyring-gpg.desktop > $HOME/.config/autostart/gnome-keyring-gpg.desktop
 
 Next, place the following in ``~/.bashrc`` to ensure gpg-agent starts with ``--enable-ssh-support``
 ::


### PR DESCRIPTION
GNOME 3 has never used gconftool, and Fedora does not use `/etc/X11/XSession.options`.

I have more changes to bring GNOME instructions up-to-date but I have to test them on a fresh VM first.
